### PR TITLE
Update NPM registry docs

### DIFF
--- a/source/includes/_react_js.md
+++ b/source/includes/_react_js.md
@@ -2,13 +2,6 @@
 
 ## Installation
 
-> **Add NPM Registry token to your `.npmrc` file**
-
-```shell
-@rotorvideos:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=<insert token here>
-``` 
-
 > **Install the package**
 
 ```shell
@@ -17,7 +10,7 @@ npm install @rotorvideos/react
 yarn add @rotorvideos/react
 ```
 
-To install the package, you need to add the NPM Registry token to your `.npmrc` file. You can find the token your
+To install the package, you need to add the NPM Registry configuration to your `.npmrc` file. You can find the config in your
 Partners Dashboard. And then you can install the package using `npm` or `yarn`.
 
 ## RotorVideosProvider


### PR DESCRIPTION
Remove the authKey and GitHub registry configuration. Mention that the `.npmrc` config can be copied from Partners Dashboard