### PR TITLE
Update registration to capture api credentials

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -67,8 +67,27 @@ curl -XPOST "https://api.rotorvideos.com/api/partner/v1/register" \
 }
 ```
 
+> **Providing optional attributes, in this case additonal Partner API credentials**
+
+```json
+{
+  "data": {
+    "type" : "access_token",
+    "attributes": {
+      "access_token": "1234567890",
+      "optional_attributes": {
+          "api_key_id": "<identifier>",
+          "secret_key": "<secret>"
+      }
+    }
+  }
+}
+```
+
 Register a user for the Partner API; if they exist in our system, an access token is returned. If not, we generate a new
 account, then return an access token for them.
+
+Depending on the scope of the integration agreed with Rotor, you may need to pass additional optional attributes. These additional attributes will be stored with the Rotor user and may be used for _eg_ reciprocal API access
 
 ### HTTP Request
 
@@ -76,6 +95,7 @@ account, then return an access token for them.
 
 ### Data Attributes
 
-| Parameter      | Description                                                 |
-|----------------|-------------------------------------------------------------|
-| remote_user_id | A unique identifier (on the partner platform) for the user. |
+| Parameter           | Description
+|---------------------|-------------------------------------------------------------|
+| remote_user_id      | A unique identifier (on the partner platform) for the user.
+| optional_attributes | (_Optional_) For some Partner integrations, additional information may need to be provided. These can be provided nested within this attribute. Unrecognised optional attributes will be ignored.

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -22,9 +22,9 @@ curl -XPOST "https://api.rotorvideos.com/oauth/token" \
 }
 ```
 
-In order to make API requests, you must first authorize the application, using the Oauth Client ID and Client Secret provided.
+In order to make API requests, you must first authorize your application, using the Oauth Client ID and Client Secret provided by Rotor to your organization.
 
-Your Application Oauth Access Token is retrieved, to be used to fetch the user's Oauth Access Token for all subsequent requests.
+This request returns your Partner Access Token which can be used to generate a User Access Token for subsequent requests.
 
 ### HTTP Request
 
@@ -38,7 +38,7 @@ Your Application Oauth Access Token is retrieved, to be used to fetch the user's
 
 ## Register/Fetch User
 
-> **Fetch the user's Oauth Access Token:**
+> **Fetch the User's Oauth Access Token:**
 
 ```shell
 curl -XPOST "https://api.rotorvideos.com/api/partner/v1/register" \


### PR DESCRIPTION
Document https://gitlab.lyricfind.com/lyricfind/lyricfind/-/issues/10702 changes, where we allow the passing of optional Partner API credentials to registration. 


<img width="1195" alt="image" src="https://github.com/user-attachments/assets/d3d89b36-7ebe-4796-8f99-c158ecf784e4">

<img width="1093" alt="image" src="https://github.com/user-attachments/assets/bf168673-4326-4609-a597-411edf1d6542">

